### PR TITLE
fix test 0333: @content overrides @datetime in the case of a typed literal

### DIFF
--- a/lib/rdf/rdfa/reader.rb
+++ b/lib/rdf/rdfa/reader.rb
@@ -1090,7 +1090,7 @@ module RDF::RDFa
           when datatype && ![RDF.XMLLiteral, RDF.HTML].include?(datatype)
             # typed literal
             add_debug(element, "[Step 11] typed literal (#{datatype})")
-            RDF::Literal.new(attrs[:datetime] || attrs[:content] || element.inner_text.to_s, :datatype => datatype, :validate => validate?, :canonicalize => canonicalize?)
+            RDF::Literal.new(attrs[:content] || attrs[:datetime] || element.inner_text.to_s, :datatype => datatype, :validate => validate?, :canonicalize => canonicalize?)
           when @version == :"rdfa1.1"
             case
             when datatype == RDF.XMLLiteral


### PR DESCRIPTION
This should fix the failing test 0333 on http://rdfa.info/test-suite/

Note that I haven't tested this code locally as I don't a distiller set up on my machine.
