### PR TITLE
Fixes attempted loading of unavailable gems

### DIFF
--- a/lib/rdf/rdfa/reader.rb
+++ b/lib/rdf/rdfa/reader.rb
@@ -374,7 +374,7 @@ module RDF::RDFa
               when 'text/turtle'         then require 'rdf/turtle'
               when 'application/ld+json' then require 'json/ld'
               end
-            rescue
+            rescue LoadError
             end
 
             if reader = RDF::Reader.for(:content_type => type)


### PR DESCRIPTION
The begin/rescue/end block here seems to only exist to handle problems with the loading of RDF formats.

However, since `LoadError` is not a subclass of `StandardError`, the existing code wouldn't have caught cases where the JSON-LD gem wasn't available. And because `json-ld` is only a development dependency of `rdf-rdfa` and not a runtime one, this could bite unsuspecting users trying to parse a document with embedded JSON linked data - in my case it was http://www.businessweek.com/articles/2014-11-21/boeings-777-problem-delta-and-other-airlines-want-newer-planes.

```
> LoadError.ancestors
 => [LoadError, ScriptError, Exception, Object, Kernel]
```

I'm not sure how to write a test around gems not being available in the load path, otherwise I would have.
