### PR TITLE
Allow use of haml 5. Fixes #23

### DIFF
--- a/rdf-rdfa.gemspec
+++ b/rdf-rdfa.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.requirements          = []
 
   gem.add_runtime_dependency     'rdf',                 '~> 2.2'
-  gem.add_runtime_dependency     'haml',                '~> 4.0'
+  gem.add_runtime_dependency     'haml',                '<6', '>= 4.0'
   gem.add_runtime_dependency     'rdf-xsd',             '~> 2.1'
   gem.add_runtime_dependency     'rdf-aggregate-repo',  '~> 2.2'
   gem.add_runtime_dependency     'htmlentities',        '~> 4.3'


### PR DESCRIPTION
When I run the test suite I see that these pending test have fixed themselves (which is counted as a failure)

```
Failures:

  1) RDF::RDFa::Reader w3c test cases for xhtml1 rdfa1.1 that are required test 0065: @rel with safe CURIE FIXED
     Expected pending 'CDN messes up email addresses' to fail. No error was raised.
     # ./spec/suite_spec.rb:16

  2) RDF::RDFa::Reader w3c test cases for xhtml1 rdfa1.1 that are required test 0176: IRI for @rel and @rev is allowed FIXED
     Expected pending 'CDN messes up email addresses' to fail. No error was raised.
     # ./spec/suite_spec.rb:16

  3) RDF::RDFa::Reader w3c test cases for xhtml5 rdfa1.1 that are required test 0065: @rel with safe CURIE FIXED
     Expected pending 'CDN messes up email addresses' to fail. No error was raised.
     # ./spec/suite_spec.rb:16

  4) RDF::RDFa::Reader w3c test cases for xhtml5 rdfa1.1 that are required test 0176: IRI for @rel and @rev is allowed FIXED
     Expected pending 'CDN messes up email addresses' to fail. No error was raised.
     # ./spec/suite_spec.rb:16

  5) RDF::RDFa::Reader w3c test cases for xhtml1 rdfa1.0 that are required test 0065: @rel with safe CURIE FIXED
     Expected pending 'CDN messes up email addresses' to fail. No error was raised.
     # ./spec/suite_spec.rb:16
```