### PR TITLE
Use the HAML `ugly: false` argument only when version is *less than* 5

### DIFF
--- a/lib/rdf/rdfa/writer.rb
+++ b/lib/rdf/rdfa/writer.rb
@@ -63,7 +63,7 @@ module RDF::RDFa
     attr :heading_predicates
 
     # to preserve whitespace without using entities
-    HAML_OPTIONS = Gem.loaded_specs['haml'].version > Gem::Version.create('5.0') ? { ugly: false } : {}
+    HAML_OPTIONS = Gem.loaded_specs['haml'].version < Gem::Version.create('5.0') ? { ugly: false } : {}
 
     # @return [Graph] Graph of statements serialized
     attr_accessor :graph

--- a/spec/writer_spec.rb
+++ b/spec/writer_spec.rb
@@ -94,7 +94,7 @@ describe RDF::RDFa::Writer do
       context "typed resource" do
         subject do
           @graph << [EX.a, RDF.type, EX.Type]
-          serialize(haml_options: {ugly: false})
+          serialize(haml_options: haml_options)
         end
 
         {
@@ -318,7 +318,7 @@ describe RDF::RDFa::Writer do
       context "xsd:string" do
         subject do
           @graph << [EX.a, EX.b, RDF::Literal.new("Albert Einstein", datatype: RDF::XSD.string)]
-          serialize(haml_options: {ugly: false})
+          serialize(haml_options: haml_options)
         end
 
         {


### PR DESCRIPTION
The code currently appears to get this exactly backwards; `ugly: false` was made the default behavior in HAML 5.0, so the current behavior causes lots of noise about `:ugly` being an invalid attribute. This patch fixes that behavior and preserves behavior for HAML < 5.0.

Would love to see this in a 1.99.3 release!